### PR TITLE
Add Zod validation

### DIFF
--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -68,23 +68,22 @@ export default function Game({
 			])
 			.select('*')
 			.single();
+
 		if (!game) {
 			return router.replace(`/game?type=${searchParams.type}&message=Could not start game`);
-		} else {
-			const participants = selectedProfiles.map((profile) => ({
-				game_id: game.id,
-				participant_id: profile.id,
-			}));
-
-			const participantsSchema = z.array(ParticipantSchema).safeParse(participants);
-			if (!participantsSchema.success) {
-				return router.replace(
-					`/game/${game.id}?message=Could not start game - invalid participants`,
-				);
-			}
-			await supabase.from('game_participants').insert(participantsSchema.data);
-			return router.push(`/game/${game.id}`);
 		}
+
+		const participants = selectedProfiles.map((profile) => ({
+			game_id: game.id,
+			participant_id: profile.id,
+		}));
+
+		const participantsSchema = z.array(ParticipantSchema).safeParse(participants);
+		if (!participantsSchema.success) {
+			return router.replace(`/game/${game.id}?message=Could not start game - invalid participants`);
+		}
+		await supabase.from('game_participants').insert(participantsSchema.data);
+		return router.push(`/game/${game.id}`);
 	};
 
 	return (

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,9 +1,5 @@
-<<<<<<< zod-validation
 import { SubmitButton } from '@/components/SubmitButton';
 import { LoginSchema, RegisterSchema } from '@/types/schemas';
-=======
-import { headers } from 'next/headers';
->>>>>>> main
 import { createClient } from '@/utils/supabase/server';
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,8 +1,8 @@
-import Link from 'next/link';
-import { headers } from 'next/headers';
-import { createClient } from '@/utils/supabase/server';
-import { redirect } from 'next/navigation';
 import { SubmitButton } from '@/components/SubmitButton';
+import { LoginSchema, RegisterSchema } from '@/types/schemas';
+import { createClient } from '@/utils/supabase/server';
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
 
 export default function Login({ searchParams }: { searchParams: { message: string } }) {
 	const signIn = async (formData: FormData) => {
@@ -10,6 +10,11 @@ export default function Login({ searchParams }: { searchParams: { message: strin
 
 		const email = formData.get('email') as string;
 		const password = formData.get('password') as string;
+		const loginSchema = LoginSchema.safeParse({ email, password });
+		if (!loginSchema.success) {
+			return redirect('/login?message=Invalid email or password');
+		}
+
 		const supabase = createClient();
 		const { error } = await supabase.auth.signInWithPassword({
 			email,
@@ -29,6 +34,11 @@ export default function Login({ searchParams }: { searchParams: { message: strin
 		const origin = headers().get('origin');
 		const email = formData.get('email') as string;
 		const password = formData.get('password') as string;
+		const registerSchema = RegisterSchema.safeParse({ email, password });
+		if (!registerSchema.success) {
+			return redirect('/login?message=Invalid email or password');
+		}
+
 		const supabase = createClient();
 
 		const { error } = await supabase.auth.signUp({

--- a/app/protected/profile/AccountForm.tsx
+++ b/app/protected/profile/AccountForm.tsx
@@ -4,6 +4,7 @@ import { createClient } from '@/utils/supabase/client';
 import { type User } from '@supabase/supabase-js';
 import { Profile } from '@/types/common';
 import Avatar from './Avatar';
+import { AccountUpdateSchema } from '@/types/schemas';
 
 export default function AccountForm({
 	profile,
@@ -29,12 +30,22 @@ export default function AccountForm({
 		try {
 			if (!profile) throw new Error('Profile not found');
 			setLoading(true);
-			const { error } = await supabase.from('profiles').upsert({
+
+			const upsertData = {
 				id: profile?.id,
 				full_name: fullname,
 				username,
 				avatar_url,
-				updated_at: new Date().toISOString(),
+				updated_at: new Date(),
+			};
+			const updateSchema = AccountUpdateSchema.safeParse(upsertData);
+			if (!updateSchema.success) {
+				throw new Error('Invalid update data');
+			}
+
+			const { error } = await supabase.from('profiles').upsert({
+				...upsertData,
+				updated_at: upsertData.updated_at.toISOString(),
 			});
 			if (error) throw error;
 			alert('Profile updated!');

--- a/components/ThrowSelector.tsx
+++ b/components/ThrowSelector.tsx
@@ -1,82 +1,97 @@
-"use client"
+'use client';
 import { Throw } from '@/types/common';
+import { ThrowSchema } from '@/types/schemas';
 import { createClient } from '@/utils/supabase/client';
 import { useState } from 'react';
 
 const ThrowSelector = ({
-    gameId,
-    userId,
-    throws
-}: {gameId: string, userId: string, throws: Throw[]}) => {
-    const supabase = createClient()
-  const [currentRound, setCurrentRound] = useState(1);
-  const [currentThrow, setCurrentThrow] = useState({ number: 1, multiplier: 1 });
+	gameId,
+	userId,
+	throws,
+}: {
+	gameId: string;
+	userId: string;
+	throws: Throw[];
+}) => {
+	const supabase = createClient();
+	const [currentRound, setCurrentRound] = useState(1);
+	const [currentThrow, setCurrentThrow] = useState({ number: 1, multiplier: 1 });
 
-  const handleNumberChange = (e:any) => {
-    setCurrentThrow((prev) => ({
-      ...prev,
-      number: parseInt(e.target.value, 10),
-    }));
-  };
+	const handleNumberChange = (e: any) => {
+		setCurrentThrow((prev) => ({
+			...prev,
+			number: parseInt(e.target.value, 10),
+		}));
+	};
 
-  const handleMultiplierChange = (e:any) => {
-    setCurrentThrow((prev) => ({
-      ...prev,
-      multiplier: parseInt(e.target.value, 10),
-    }));
-  };
+	const handleMultiplierChange = (e: any) => {
+		setCurrentThrow((prev) => ({
+			...prev,
+			multiplier: parseInt(e.target.value, 10),
+		}));
+	};
 
-  const handleSubmit = async (e:any) => {
-    e.preventDefault();
-    const {data: addedThrow } = await supabase.from('throws').insert([{
-        value: currentThrow.number * currentThrow.multiplier,
-        sector: currentThrow.number,
-        multiplier: currentThrow.multiplier,
-        round: currentRound,
-        user_id: userId,
-        game_id: gameId,
-    }]).select("*").single()
-    setCurrentThrow({ number: 1, multiplier: 1 });
-    setCurrentRound((prev) => throws.length % 3 === 0 ? prev + 1 : prev)
-  };
+	const handleSubmit = async (e: any) => {
+		e.preventDefault();
+		const throwData = {
+			value: currentThrow.number * currentThrow.multiplier,
+			sector: currentThrow.number,
+			multiplier: currentThrow.multiplier,
+			round: currentRound,
+			user_id: userId,
+			game_id: gameId,
+		};
+		const throwSchema = ThrowSchema.safeParse(throwData);
+		if (!throwSchema.success) {
+			throw new Error('Invalid throw data');
+		}
 
-  return (
-      <form onSubmit={handleSubmit} className="mb-4">
-        <div className="mb-2">
-          <label className="block text-sm font-medium text-gray-700">Sector</label>
-          <select
-            value={currentThrow.number}
-            onChange={handleNumberChange}
-            className="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-          >
-            {[...Array(20)].map((_, i) => (
-              <option key={i + 1} value={i + 1}>
-                {i + 1}
-              </option>
-            ))}
-            <option value={25}>25</option>
-          </select>
-        </div>
-        <div className="mb-2">
-          <label className="block text-sm font-medium text-gray-700">Multiplier</label>
-          <select
-            value={currentThrow.multiplier}
-            onChange={handleMultiplierChange}
-            className="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-          >
-            <option value={1}>1</option>
-            <option value={2}>2</option>
-            {currentThrow.number !== 25 && <option value={3}>3</option>}
-          </select>
-        </div>
-        <button
-          type="submit"
-          className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-        >
-          Add Throw
-        </button>
-      </form>
-  );
+		const { data: addedThrow } = await supabase
+			.from('throws')
+			.insert([throwSchema.data])
+			.select('*')
+			.single();
+		setCurrentThrow({ number: 1, multiplier: 1 });
+		setCurrentRound((prev) => (throws.length % 3 === 0 ? prev + 1 : prev));
+	};
+
+	return (
+		<form onSubmit={handleSubmit} className="mb-4">
+			<div className="mb-2">
+				<label className="block text-sm font-medium text-gray-700">Sector</label>
+				<select
+					value={currentThrow.number}
+					onChange={handleNumberChange}
+					className="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+				>
+					{[...Array(20)].map((_, i) => (
+						<option key={i + 1} value={i + 1}>
+							{i + 1}
+						</option>
+					))}
+					<option value={25}>25</option>
+				</select>
+			</div>
+			<div className="mb-2">
+				<label className="block text-sm font-medium text-gray-700">Multiplier</label>
+				<select
+					value={currentThrow.multiplier}
+					onChange={handleMultiplierChange}
+					className="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+				>
+					<option value={1}>1</option>
+					<option value={2}>2</option>
+					{currentThrow.number !== 25 && <option value={3}>3</option>}
+				</select>
+			</div>
+			<button
+				type="submit"
+				className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+			>
+				Add Throw
+			</button>
+		</form>
+	);
 };
 
 export default ThrowSelector;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
 				"react": "18.2.0",
 				"react-dom": "18.2.0",
 				"tailwindcss": "3.4.1",
-				"typescript": "5.3.3"
+				"typescript": "5.3.3",
+				"zod": "^3.23.8"
 			},
 			"devDependencies": {
 				"@types/lodash": "^4.17.4",
@@ -5423,6 +5424,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "3.23.8",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+			"integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
 		"tailwindcss": "3.4.1",
-		"typescript": "5.3.3"
+		"typescript": "5.3.3",
+		"zod": "^3.23.8"
 	},
 	"devDependencies": {
 		"@types/lodash": "^4.17.4",

--- a/types/schemas.ts
+++ b/types/schemas.ts
@@ -52,3 +52,17 @@ export const RegisterSchema = z.object({
 	email: z.string().email(),
 	password: z.string().min(6),
 });
+
+/**
+ * Schema for validating the account update data.
+ * Most fields are nullable because they are optional and `null` is a valid value.
+ *
+ * `updated_at` is required because it should be set to the current date and time.
+ */
+export const AccountUpdateSchema = z.object({
+	id: z.string().min(1).optional(),
+	full_name: z.string().min(1).nullable(),
+	username: z.string().min(1).nullable(),
+	avatar_url: z.string().url().nullable(),
+	updated_at: z.date(),
+});

--- a/types/schemas.ts
+++ b/types/schemas.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+const GameTypeSchemaType = z.union([z.literal('competitive'), z.literal('practice')]);
+export type GameType = z.infer<typeof GameModeSchemaType>;
+const GameModeSchemaType = z.union([z.literal('501'), z.literal('around_the_clock')]);
+export type GameModes = z.infer<typeof GameModeSchemaType>;
+
+/**
+ * Represents the schema for validating the
+ * start game request properties.
+ */
+export const StartGameSchema = z.object({
+	type: GameTypeSchemaType,
+	game_mode: GameModeSchemaType,
+});
+
+/**
+ * Represents the schema for a single participant in a game.
+ * To validate a list of participants, use `z.array(ParticipantSchema)`.
+ */
+export const ParticipantSchema = z.object({
+	profile_id: z.string().min(1),
+	game_id: z.string().min(1),
+});

--- a/types/schemas.ts
+++ b/types/schemas.ts
@@ -22,3 +22,33 @@ export const ParticipantSchema = z.object({
 	profile_id: z.string().min(1),
 	game_id: z.string().min(1),
 });
+
+/**
+ * Schema for validating login data.
+ *
+ * The password requirement is set to a minimum of 6 characters
+ * and should be revised to meet specific security requirements.
+ */
+export const LoginSchema = z.object({
+	email: z.string().email(),
+	// TODO: rethink the password requirements here!
+	password: z.string().min(6),
+});
+
+/**
+ * Schema for validating registration data.
+ *
+ * The password requirement is set to a minimum of 6 characters
+ * and should be revised to meet specific security requirements.
+ *
+ * Also, the registration data should include a password confirmation field.
+ *
+ * **NOTE: registration currently grabs the `origin` from the header, which is _not_ part of the validation schema**.
+ * So basically we can use the `LoginSchema` for registration as well,
+ * but there might be a password confirmation field later
+ * or other fields that are not part of the login schema, like the origin.
+ */
+export const RegisterSchema = z.object({
+	email: z.string().email(),
+	password: z.string().min(6),
+});

--- a/types/schemas.ts
+++ b/types/schemas.ts
@@ -66,3 +66,22 @@ export const AccountUpdateSchema = z.object({
 	avatar_url: z.string().url().nullable(),
 	updated_at: z.date(),
 });
+
+/**
+ * Schema for validating the throw data.
+ *
+ * - `value` is the result of the throw, which is the sector multiplied by the multiplier.
+ * - `sector` is the number on the dartboard, ranging from 1 to 20 and 25 for the bullseye.
+ * - `multiplier` is the multiplier of the sector, which can be 1, 2, or 3.
+ * - `round` is the current round of the game.
+ * - `user_id` is the ID of the user who threw the dart.
+ * - `game_id` is the ID of the game in which the throw was made.
+ */
+export const ThrowSchema = z.object({
+	value: z.number(),
+	sector: z.number().min(1).max(25),
+	multiplier: z.number().min(1).max(3),
+	round: z.number().min(1),
+	user_id: z.string().min(1),
+	game_id: z.string().min(1),
+});


### PR DESCRIPTION
This PR adds Zod validation to all server-side actions involving user-generated data. These actions include:

- Login & Register
- Throw selector
- Profile/Account update form
- Game start data and participants information

The Zod schemas are located in `types/schemas.ts` and are all used with `safeParse`, allowing for easier handling of validation failures.

The schema types generally align with the specified validation requirements, such as using `z.string().email()` for the login email. However, some types should be revisited and potentially adjusted to better meet the application's needs, such as the minimum password length in the login and register schemas.

This fixes #1 